### PR TITLE
リクエスト機能の一覧のページネーション実装まで

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -50,5 +50,6 @@ module.exports = {
         ],
       },
     ],
+    "react/prop-types": "off", // TSの型定義で十分、冗長になってしまうため追加
   },
 };

--- a/src/components/Book/BookCard.tsx
+++ b/src/components/Book/BookCard.tsx
@@ -1,0 +1,83 @@
+import {
+  Card,
+  CardMedia,
+  Typography,
+  CardActionArea,
+  Box,
+  CircularProgress,
+} from "@mui/material";
+import { Link } from "react-router-dom";
+
+import { BookInformation } from "@/types/interface";
+
+export const BookCard: React.FC<{
+  bookInfo: BookInformation;
+  loading: boolean;
+}> = ({ bookInfo, loading }) => (
+  <Card sx={{ position: "relative", overflow: "hidden" }}>
+    <CardActionArea component={Link} to="/requests/detail">
+      {loading ? (
+        <Box
+          sx={{
+            height: "300px",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <CardMedia
+          component="img"
+          height="300"
+          image={bookInfo.image_path}
+          alt="Book cover"
+          sx={{ transition: "opacity 0.3s", "&:hover": { opacity: 0.5 } }}
+        />
+      )}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          bgcolor: "rgba(0, 0, 0, 0.7)",
+          opacity: 0,
+          transition: "opacity 0.3s",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          p: 2,
+          color: "white",
+          "&:hover": { opacity: 1 },
+        }}
+      >
+        <Typography variant="h6" component="h3" gutterBottom>
+          {bookInfo.title}
+        </Typography>
+        <Typography variant="body2">{bookInfo.author}</Typography>
+        <Typography variant="body2">{bookInfo.description}</Typography>
+        <Typography variant="body2">
+          Published {bookInfo.published_date.toString()}
+        </Typography>
+      </Box>
+    </CardActionArea>
+    <Box sx={{ p: 2, height: "4em", display: "flex", alignItems: "center" }}>
+      <Typography
+        variant="subtitle1"
+        component="h3"
+        sx={{
+          display: "-webkit-box",
+          WebkitLineClamp: "2",
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {bookInfo.title}
+      </Typography>
+    </Box>
+  </Card>
+);

--- a/src/components/Book/BooksArea.tsx
+++ b/src/components/Book/BooksArea.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import { Grid, Box } from "@mui/material";
+
+import { BookCard } from "./BookCard";
+
+import { BookRequest } from "@/types/interface";
+
+interface BooksAreaProps {
+  bookRequests: BookRequest[];
+  loading: boolean;
+}
+
+export const BooksArea: React.FC<BooksAreaProps> = ({
+  bookRequests,
+  loading,
+}) => {
+  return (
+    <Box py={12}>
+      <Box maxWidth="lg" mx="auto" px={4}>
+        <Box bgcolor="grey.100" p={4}>
+          <Grid
+            container
+            spacing={4}
+            sx={{ overflowY: "auto", maxHeight: "70vh", pr: 2 }}
+          >
+            {bookRequests.map((bookRequest, index) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
+                <BookCard
+                  bookInfo={bookRequest.book.book_information}
+                  loading={loading}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/Common/Pagination.tsx
+++ b/src/components/Common/Pagination.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { Pagination } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+const BlackPagination = styled(Pagination)({
+  "& .MuiPaginationItem-root": {
+    color: "#000000",
+  },
+  "& .MuiPaginationItem-page.Mui-selected": {
+    backgroundColor: "#000000",
+    color: "#FFFFFF",
+  },
+});
+
+interface PaginationProps {
+  totalCount: number;
+  currentPage: number;
+  perPage: number;
+  onPageChange: (event: React.ChangeEvent<unknown>, page: number) => void;
+}
+
+export const PaginationComponent: React.FC<PaginationProps> = ({
+  totalCount,
+  currentPage,
+  perPage,
+  onPageChange,
+}) => {
+  return (
+    <BlackPagination
+      count={Math.ceil(totalCount / perPage)}
+      page={currentPage}
+      onChange={onPageChange}
+    />
+  );
+};

--- a/src/features/request/queries.ts
+++ b/src/features/request/queries.ts
@@ -1,0 +1,32 @@
+import { gql } from "@apollo/client";
+
+export const PAGINATED_BOOK_REQUESTS = gql`
+  query PaginatedBookRequests($page: Int!, $perPage: Int!) {
+    paginatedBookRequests(page: $page, perPage: $perPage) {
+      totalCount
+      currentPage
+      perPage
+      bookRequests {
+        id
+        book {
+          id
+          user_id
+          book_information {
+            book_information_id
+            isbn_number
+            title
+            author
+            published_date
+            description
+            image_path
+          }
+          donation_date
+        }
+        requester_id
+        holder_id
+        request_date
+        status
+      }
+    }
+  }
+`;

--- a/src/pages/request/RequestBooksPage.tsx
+++ b/src/pages/request/RequestBooksPage.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+import { useQuery } from "@apollo/client";
+import { Box } from "@mui/material";
+
+import { BooksArea } from "../../components/Book/BooksArea";
+import { PaginationComponent } from "../../components/Common/Pagination";
+
+import { PAGINATED_BOOK_REQUESTS } from "@/features/request/queries";
+import { PaginationData } from "@/types/interface";
+
+const RequestBooksPage: React.FC = () => {
+  const [currentPage, setCurrentPage] = React.useState(1);
+  const { data, loading, error, refetch } = useQuery<{
+    paginatedBookRequests: PaginationData;
+  }>(PAGINATED_BOOK_REQUESTS, {
+    variables: {
+      page: currentPage,
+      perPage: 12,
+    },
+  });
+
+  if (error) return <p>Error: {error.message}</p>;
+
+  const handlePageChange = (
+    event: React.ChangeEvent<unknown>,
+    page: number,
+  ) => {
+    setCurrentPage(page);
+    refetch({
+      page: page,
+      perPage: 12,
+    });
+  };
+
+  return (
+    <Box>
+      <BooksArea
+        bookRequests={data?.paginatedBookRequests.bookRequests || []}
+        loading={loading}
+      />
+      <Box mt={4} display="flex" justifyContent="center">
+        <PaginationComponent
+          totalCount={data?.paginatedBookRequests.totalCount || 0}
+          currentPage={currentPage}
+          perPage={data?.paginatedBookRequests.perPage || 12}
+          onPageChange={handlePageChange}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default RequestBooksPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import ImageUploadPage from "./pages/donation/ImageUploadPage";
 import ISBNInputPage from "./pages/donation/ISBNInputPage";
 import MainSelectionPage from "./pages/donation/MainSelectionPage";
 import MockCardsPage from "./pages/mock/MockCardsPage";
+import RequestBooksPage from "./pages/request/RequestBooksPage";
 
 import MainLayout from "@/components/Layout/MainLayout";
 import MockAboutPage from "@/pages/mock/MockAboutPage";
@@ -29,6 +30,12 @@ const router = createBrowserRouter(
           <Route path="scan-barcode" element={<BarcodeScannerPage />} />
           {/* <Route path="confirm-book" element={} /> */}
           {/* <Route path="confirm-donation" element={} /> */}
+        </Route>
+        <Route path="requests">
+          {/* リクエスト一覧 PATH */}
+          {/* TODO: 各ページの作成  */}
+          <Route index element={<RequestBooksPage />} />
+          {/* <Route path="selection" element={<MainSelectionPage />} /> */}
         </Route>
       </Route>
       <Route path="/mock">

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -1,0 +1,32 @@
+export interface BookInformation {
+  id: number;
+  isbn_number: number;
+  title: string;
+  author: string;
+  published_date: Date;
+  description: string;
+  image_path: string;
+}
+
+export interface Book {
+  id: number;
+  user_id: number;
+  book_information: BookInformation;
+  donation_date: Date;
+}
+
+export interface BookRequest {
+  id: string;
+  book: Book;
+  requester_id: number;
+  holder_id: number;
+  request_date: Date;
+  status: "requested" | "sending" | "arrived";
+}
+
+export interface PaginationData {
+  totalCount: number;
+  currentPage: number;
+  perPage: number;
+  bookRequests: BookRequest[];
+}


### PR DESCRIPTION
#  プルリクエスト概要
リクエスト機能の一覧のページネーション実装まで

## やったこと
- リクエスト機能（ページネーションまで）
- **eslintの設定でreact/prop-typesをオフに**

## やらないこと
- 詳細画面の実装

## その他
- TSの型定義と重なって冗長になる、エラーが頻発してしまうためeslintの設定でprop-typesオフにさせてもろてます。