### PR TITLE
[fix]本が到着した際にbook_loanレコードを作成するように修正

### DIFF
--- a/src/features/request/mutations.ts
+++ b/src/features/request/mutations.ts
@@ -1,8 +1,18 @@
 import { gql } from "@apollo/client";
 
 export const UPDATE_BOOK_REQUEST_STATUS = gql`
-  mutation UpdateBookRequestStatus($requestId: String!, $status: String!) {
-    updateBookRequestStatus(requestId: $requestId, status: $status) {
+  mutation UpdateBookRequestStatus(
+    $requestId: String!
+    $status: String!
+    $userId: String
+    $bookId: Int
+  ) {
+    updateBookRequestStatus(
+      requestId: $requestId
+      status: $status
+      userId: $userId
+      bookId: $bookId
+    ) {
       id
       status
     }

--- a/src/pages/request/RequestDetailPage.tsx
+++ b/src/pages/request/RequestDetailPage.tsx
@@ -24,9 +24,20 @@ const RequestDetailPage: React.FC = () => {
   });
 
   const handleConfirmAction = async (status: string) => {
-    await updateBookRequestStatus({
-      variables: { requestId: bookRequest.id, status },
-    });
+    if (status === "arrived") {
+      await updateBookRequestStatus({
+        variables: {
+          requestId: bookRequest.id,
+          status,
+          userId: userId,
+          bookId: parseInt(bookRequest.book.id),
+        },
+      });
+    } else {
+      await updateBookRequestStatus({
+        variables: { requestId: bookRequest.id, status },
+      });
+    }
     await refetch({ requestId: bookRequest.id });
     setModalOpen(false);
   };


### PR DESCRIPTION
#  プルリクエスト概要
Status変更だけでなく、もしstatusを"arrived"に変更するリクエストの場合はuser_idとbook_idを一緒にリクエストに含めてバックエンドでbook_loandを作成できるように修正する